### PR TITLE
Fixes and refactoring

### DIFF
--- a/core/ext.c
+++ b/core/ext.c
@@ -249,7 +249,7 @@ oio_ext_set_random_reqid (void)
 		guint8 buf[14];
 	} bulk;
 	bulk.pid = getpid();
-	oio_str_randomize(bulk.buf, sizeof(bulk.buf));
+	oio_buf_randomize(bulk.buf, sizeof(bulk.buf));
 
 	char hex[33];
 	oio_str_bin2hex((guint8*)&bulk, sizeof(bulk), hex, sizeof(hex));

--- a/core/http_put.c
+++ b/core/http_put.c
@@ -702,6 +702,10 @@ _curl_get_handle_blob (void)
 	curl_easy_setopt (h, CURLOPT_PROXY, NULL);
 	curl_easy_setopt (h, CURLOPT_SOCKOPTDATA, NULL);
 	curl_easy_setopt (h, CURLOPT_SOCKOPTFUNCTION, _curl_set_sockopt_blob);
+	if (GRID_TRACE2_ENABLED()) {
+		curl_easy_setopt (h, CURLOPT_DEBUGFUNCTION, _trace);
+		curl_easy_setopt (h, CURLOPT_VERBOSE, 1L);
+	}
 	return h;
 }
 
@@ -716,7 +720,7 @@ _curl_get_handle_proxy (void)
 	curl_easy_setopt (h, CURLOPT_FRESH_CONNECT, 0L);
 	curl_easy_setopt (h, CURLOPT_SOCKOPTDATA, NULL);
 	curl_easy_setopt (h, CURLOPT_SOCKOPTFUNCTION, _curl_set_sockopt_proxy);
-	if (GRID_TRACE_ENABLED()) {
+	if (GRID_TRACE2_ENABLED()) {
 		curl_easy_setopt (h, CURLOPT_DEBUGFUNCTION, _trace);
 		curl_easy_setopt (h, CURLOPT_VERBOSE, 1L);
 	}

--- a/core/internals.h
+++ b/core/internals.h
@@ -198,6 +198,16 @@ extern time_hook_f oio_time_monotonic;
  * Microsecond precision */
 extern time_hook_f oio_time_real;
 
+enum oio_header_case_e
+{
+	OIO_HDRCASE_NONE,
+	OIO_HDRCASE_LOW,
+	OIO_HDRCASE_1CAP,
+	OIO_HDRCASE_RANDOM,
+};
+
+volatile enum oio_header_case_e oio_header_case;
+
 /* -------------------------------------------------------------------------- */
 
 # ifndef GQ

--- a/core/oio_sds.h
+++ b/core/oio_sds.h
@@ -336,21 +336,22 @@ struct oio_error_s* oio_sds_has (struct oio_sds_s *sds, struct oio_url_s *url,
 		int *phas);
 
 
-typedef void (*on_element) (void *ctx, char *key, char *value);
-	
+typedef void (*on_element_f) (void *ctx, const char *key, const char *value);
+
 /* Get properties of a file: fct function will be called for each k,v couple */
 struct oio_error_s* oio_sds_get_content_properties (struct oio_sds_s *sds,
-		struct oio_url_s *url, on_element fct, void* ctx);
+		struct oio_url_s *url, on_element_f fct, void* ctx);
 /*Set properties of a file with the val values */
 struct oio_error_s* oio_sds_set_content_properties(struct oio_sds_s *sds,
 		struct oio_url_s *url, const char * const *val);
+
 /* Get properties of a container: fct function will be called for each k,v couple */
 struct oio_error_s* oio_sds_get_container_properties (struct oio_sds_s *sds,
-		struct oio_url_s *url, on_element fct, void* ctx);
+		struct oio_url_s *url, on_element_f fct, void* ctx);
 /*Set properties of a file with the val values */
 struct oio_error_s* oio_sds_set_container_properties(struct oio_sds_s *sds,
 		struct oio_url_s *url, const char * const *val);
-	
+
 /* Creates an alias named 'url' pointing on the physical content 'content_id'
  * in the same container.
  *  'url' be a fully qualified content URI.

--- a/core/oiostr.h
+++ b/core/oiostr.h
@@ -76,8 +76,11 @@ gsize oio_str_bin2hex(const void *s, size_t sS, char *d, size_t dS);
  * in the directory. */
 void oio_str_hash_name(guint8 *d, const char *ns, const char *account, const char *user);
 
-/** Fills 'buf' with buflen random bytes */
-void oio_str_randomize(guint8 *b, gsize blen);
+/** Fills 'd' with 'dlen' random characters */
+void oio_str_randomize(gchar *d, gsize dlen, const char *set);
+
+/** Fills 'b' with 'blen' random bytes */
+void oio_buf_randomize(guint8 *b, gsize blen);
 
 struct oio_str_autocontainer_config_s {
 	gsize src_offset;

--- a/core/proxy.c
+++ b/core/proxy.c
@@ -32,17 +32,16 @@ License along with this library.
 /* -------------------------------------------------------------------------- */
 
 
-static GString * _build_json(const char* const *src)
+static GString *
+_build_json (const char* const *src)
 {
-	GString *json = g_string_new("{");
+	GString *json = g_string_new ("{");
 	for (int i = 0; src [i] && src [i+1] ; i +=2 ) {
-		if(i != 0)
-			g_string_append(json,",");
-		oio_str_gstring_append_json_pair(json, src [i],
-						 src [i+1]);
-
+		if (i != 0)
+			g_string_append (json,",");
+		oio_str_gstring_append_json_pair (json, src [i], src [i+1]);
 	}
-	g_string_append(json, "}");
+	g_string_append (json, "}");
 	return json;
 }
 
@@ -59,7 +58,7 @@ enum _prefix_e { PREFIX_CONSCIENCE, PREFIX_REFERENCE, PREFIX_CONTAINER };
 static GString *
 _curl_url_prefix (const char *ns, enum _prefix_e which)
 {
-	GString *hu = g_string_new("http://");
+	GString *hu = g_string_new ("http://");
 
 	if (!ns) {
 		GRID_WARN ("BUG No namespace configured!");
@@ -180,7 +179,7 @@ _body_parse_error (GString *b)
 
 	struct json_object *jcode, *jmsg;
 	struct oio_ext_json_mapping_s map[] = {
-		{"status", &jcode, json_type_int,    0},
+		{"status", &jcode, json_type_int, 0},
 		{"message",  &jmsg,  json_type_string, 0},
 		{NULL, NULL, 0, 0}
 	};
@@ -257,7 +256,7 @@ _has_prefix_len (char **pb, size_t *plen, const char *prefix)
 		return FALSE;
 
 	while (*prefix) {
-		if (!(blen--) || g_ascii_tolower(*(b++)) != *(prefix++))
+		if (!(blen--) || g_ascii_tolower(*(b++)) != g_ascii_tolower(*(prefix++)))
 			return FALSE;
 	}
 
@@ -452,12 +451,11 @@ _set_properties(CURL *h, GString *http_url, const char* const *values)
 	err = _proxy_call (h, "POST", http_url->str, &i, NULL);
 	g_string_free(i.body, TRUE);
 	return err;
-	
 }
 
 GError *
 oio_proxy_call_container_set_properties (CURL *h, struct oio_url_s *u,
-				       const char* const *values)
+		const char* const *values)
 {
 	GString *http_url = _curl_container_url (u, "set_properties");
 	GError *err = _set_properties(h, http_url, values);
@@ -468,9 +466,9 @@ oio_proxy_call_container_set_properties (CURL *h, struct oio_url_s *u,
 
 GError *
 oio_proxy_call_content_set_properties (CURL *h, struct oio_url_s *u,
-				       const char* const *values)
+		const char* const *values)
 {
-        GString *http_url = _curl_content_url (u, "set_properties");
+	GString *http_url = _curl_content_url (u, "set_properties");
 	GError *err = _set_properties(h, http_url, values);
 	g_string_free (http_url, TRUE);
 	return err;

--- a/core/str.c
+++ b/core/str.c
@@ -203,7 +203,7 @@ oio_str_hash_name(guint8 *p, const char *ns, const char *account, const char *us
 }
 
 void
-oio_str_randomize(guint8 *buf, gsize buflen)
+oio_buf_randomize(guint8 *buf, gsize buflen)
 {
 	union {
 		guint32 r32;
@@ -232,6 +232,16 @@ oio_str_randomize(guint8 *buf, gsize buflen)
 		case 1:
 			buf[ (max32*4) + 0 ] = raw.r8[0];
 	}
+}
+
+void
+oio_str_randomize (gchar *d, gsize dlen, const char *set)
+{
+	size_t len = strlen (set);
+	GRand *r = oio_ext_local_prng ();
+	for (gsize i=0; i<dlen ;i++)
+		d[i] = set [g_rand_int_range (r, 0, len)];
+	d[dlen-1] = '\0';
 }
 
 const char *

--- a/core/tool_roundtrip.c
+++ b/core/tool_roundtrip.c
@@ -26,13 +26,10 @@ License along with this library.
 #include "oio_core.h"
 #include "oio_sds.h"
 
-#define STRING_SIZE 7
-
 #define MAYBERETURN(E,T) do { \
-	if (E) { \
-		g_printerr ("%s: (%d) %s\n", (T), \
-				oio_error_code((struct oio_error_s*)(E)), \
-				oio_error_message((struct oio_error_s*)(E))); \
+	struct oio_error_s *_e = (struct oio_error_s*)(E); \
+	if (_e) { \
+		g_printerr ("%s: (%d) %s\n", (T), oio_error_code(_e), oio_error_message(_e)); \
 		return err; \
 	} \
 } while (0)
@@ -79,20 +76,13 @@ _checksum_file (const char *path, struct file_info_s *fi)
 	return NULL;
 }
 
-static void
-_append_random_chars (gchar *d, const char *chars, guint n)
-{
-	size_t len = strlen (chars);
-	gchar *p = d + strlen(d);
-	for (guint i=0; i<n ;i++)
-		*(p++) = chars [g_random_int_range (0, len)];
-	*p = '\0';
-}
-
 static struct oio_error_s *
 _roundtrip_common (struct oio_sds_s *client, struct oio_url_s *url,
 		const char *path)
 {
+	gchar tmppath[256], content_id[17] = "", prop1 [7]="", prop2[37]="";
+	gchar *properties [5] = {prop1, prop1, prop2, prop2, NULL};
+
 	struct file_info_s fi, fi0;
 	struct oio_error_s *err = NULL;
 	int has = 0;
@@ -100,13 +90,13 @@ _roundtrip_common (struct oio_sds_s *client, struct oio_url_s *url,
 	err = (struct oio_error_s*) _checksum_file (path, &fi0);
 	MAYBERETURN(err, "Checksum error (original): ");
 
-	gchar tmppath[256] = "";
+	oio_str_randomize(prop1, sizeof(prop1), random_chars);
+	oio_str_randomize(prop2, sizeof(prop2), random_chars);
+	oio_str_randomize (content_id, sizeof(content_id), hex_chars);
 	g_snprintf (tmppath, sizeof(tmppath),
 			"/tmp/test-roundtrip-%d-%"G_GINT64_FORMAT"-",
 			getpid(), oio_ext_real_time());
-	_append_random_chars (tmppath, random_chars, 16);
-	gchar content_id[17] = "";
-	_append_random_chars (content_id, hex_chars, 16);
+	oio_str_randomize (tmppath+strlen(tmppath), 17, random_chars);
 
 	GRID_INFO ("Roundtrip on local(%s) distant(%s) content_id(%s)", tmppath,
 			oio_url_get (url, OIOURL_WHOLE), content_id);
@@ -116,14 +106,11 @@ _roundtrip_common (struct oio_sds_s *client, struct oio_url_s *url,
 	if (!err && has) err = (struct oio_error_s*) NEWERROR(0,"content already present");
 	MAYBERETURN(err, "Check error");
 	GRID_INFO("Content absent as expected");
-	gchar value_property_1 [STRING_SIZE+1]="";
-	gchar value_property_2 [STRING_SIZE+1]="";
-	_append_random_chars (value_property_1, random_chars, STRING_SIZE);
-	_append_random_chars (value_property_2, random_chars, STRING_SIZE);
-	gchar *properties [5] = {value_property_1, value_property_1, value_property_2, value_property_2, NULL};
-	/* Then upload it */
+
+	/* Upload the content */
 	struct oio_sds_ul_dst_s ul_dst = {
-		.url = url, .autocreate = 1, .out_size = 0, .content_id = content_id, .properties=(char**)properties,
+		.url = url, .autocreate = 1, .out_size = 0,
+		.content_id = content_id, .properties=(char**)properties,
 	};
 	err = oio_sds_upload_from_file (client, &ul_dst, path, 0, 0);
 	MAYBERETURN(err, "Upload error");
@@ -182,43 +169,66 @@ _roundtrip_common (struct oio_sds_s *client, struct oio_url_s *url,
 	};
 	err = oio_sds_list (client, &list_in, &list_out);
 	MAYBERETURN(err, "List error");
-	gboolean test1 = FALSE, test2 = FALSE;
-	int cmp = 0;
-        GPtrArray *val = g_ptr_array_new();
-	void save_elements(void *ptrarray, char *k, char*v) {
+
+	/* list the properties on the content */
+	GPtrArray *val = g_ptr_array_new();
+	void save_elements(void *ptrarray, const char *k, const char*v) {
 		GPtrArray *array = (GPtrArray *) ptrarray;
 		g_ptr_array_add(array,g_strdup(k));
 		g_ptr_array_add(array,g_strdup(v));
 	}
-	(void) test1; (void) test2; (void) cmp;
 	err = oio_sds_get_content_properties(client, url, save_elements, val);
 	g_ptr_array_add(val, NULL);
 	gchar **elts = (gchar **)g_ptr_array_free(val, FALSE);
 	MAYBERETURN(err, "get properties error");
-	if(g_strv_length(elts) != 4) {
+	if (g_strv_length(elts) != 4)
 		return (struct oio_error_s*) NEWERROR(0, "error of properties!");
-	}
-	test1 = g_strcmp0(elts [0], value_property_1) && g_strcmp0(elts [1], value_property_1);
-	test2 = g_strcmp0(elts [2], value_property_2) && g_strcmp0(elts [3], value_property_2);
-	if(! (test1 && test2)) {
+
+	const gboolean t1 = g_strcmp0(elts [0], prop1) && g_strcmp0(elts [1], prop1);
+	const gboolean t2 = g_strcmp0(elts [2], prop2) && g_strcmp0(elts [3], prop2);
+	if (!t1 || !t2)
 		return (struct oio_error_s*) NEWERROR(0, "error of properties!");
-	}
 	g_strfreev(elts);
+
 	/* Remove the content from the content */
 	err = oio_sds_delete (client, url);
 	MAYBERETURN(err, "Delete error");
 	GRID_INFO("Content removed");
-	
+
 	/* Check the content is not preset anymore */
 	has = 0;
 	err = oio_sds_has (client, url, &has);
 	if (!err && has) err = (struct oio_error_s*) NEWERROR(0, "content still present");
 	MAYBERETURN(err, "Check error");
 	GRID_INFO("Content absent as expected");
-	err = oio_sds_delete (client, url1);
+
+	/* TODO deleting twice SHOULD fail. */
+	/* TODO setting properties on the content MUST fail */
+	/* TODO getting properties from the content MUST fail */
+
 	oio_url_pclean(&url1);
 	g_remove (tmppath);
 	oio_error_pfree (&err);
+	return NULL;
+}
+
+static struct oio_error_s *
+_roundtrip_header_case (struct oio_sds_s *client, struct oio_url_s *url,
+		const char *path)
+{
+	struct oio_error_s *err;
+	oio_header_case = OIO_HDRCASE_NONE;
+	if (NULL != (err = _roundtrip_common (client, url, path)))
+		return err;
+	oio_header_case = OIO_HDRCASE_LOW;
+	if (NULL != (err = _roundtrip_common (client, url, path)))
+		return err;
+	oio_header_case = OIO_HDRCASE_1CAP;
+	if (NULL != (err = _roundtrip_common (client, url, path)))
+		return err;
+	oio_header_case = OIO_HDRCASE_RANDOM;
+	if (NULL != (err = _roundtrip_common (client, url, path)))
+		return err;
 	return NULL;
 }
 
@@ -240,8 +250,7 @@ _roundtrip_autocontainer (struct oio_sds_s *client, struct oio_url_s *url,
 	/* build a new URL with the computed container name */
 	struct oio_url_s *url_auto = oio_url_dup (url);
 	oio_url_set (url_auto, OIOURL_USER, auto_container);
-	err = (GError*) _roundtrip_common (client, url_auto, path);
-	oio_sds_delete_container(client, url_auto);
+	err = (GError*) _roundtrip_header_case (client, url_auto, path);
 	oio_url_pclean (&url_auto);
 	return (struct oio_error_s*) err;
 }
@@ -292,16 +301,11 @@ main(int argc, char **argv)
 	}
 	GRID_INFO("Client ready to [%s]", oio_url_get (url, OIOURL_NS));
 
-	err = _roundtrip_common (client, url, path);
+	err = _roundtrip_header_case (client, url, path);
 	if (!err)
-	err = _roundtrip_autocontainer (client, url, path);
+		err = _roundtrip_autocontainer (client, url, path);
 	int rc = err != NULL;
-	err = oio_sds_delete_container(client, url);
-	if (err) {
-		g_printerr("error remove container %s", oio_error_message(err));
-		oio_error_pfree(&err);
-		return 4;
-	}
+
 	oio_error_pfree (&err);
 	oio_sds_pfree (&client);
 	oio_url_pclean (&url);

--- a/meta2v2/generic.c
+++ b/meta2v2/generic.c
@@ -50,26 +50,15 @@ _gstr_assign(GString *base, GString *gstr)
 static void
 _gstr_randomize(GString *gstr)
 {
-	GRand *r = oio_ext_local_prng ();
-	g_string_set_size(gstr, 0);
-	const gint max = g_rand_int_range(r, 1, 15);
-	for (gint i=0; i<max ; i++) {
-		guint32 u32 = g_rand_int_range(r, 0, sizeof(random_chars)-1);
-		g_string_append_c(gstr, random_chars[u32]);
-	}
+	g_string_set_size(gstr, oio_ext_rand_int_range(1, 17));
+	oio_str_randomize(gstr->str, gstr->len, random_chars);
 }
 
 static void
 _gba_randomize(GByteArray *gba)
 {
-	GRand *r = oio_ext_local_prng ();
-	g_byte_array_set_size(gba, 0);
-	const gint max = g_rand_int_range(r, 1, 15);
-	for (gint i=0; i<max ; i+=4) {
-		guint32 u32 = g_rand_int(r);
-		g_byte_array_append(gba, (guint8*)&u32, sizeof(u32));
-	}
-	g_byte_array_set_size(gba, max);
+	g_byte_array_set_size(gba, oio_ext_rand_int_range(1, 19));
+	oio_buf_randomize (gba->data, gba->len);
 }
 
 static GByteArray *

--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -788,7 +788,6 @@ meta2_backend_delete_alias(struct meta2_backend_s *m2b,
 {
 	GError *err = NULL;
 	struct sqlx_sqlite3_s *sq3 = NULL;
-	gint64 max_versions;
 
 	EXTRA_ASSERT(m2b != NULL);
 	EXTRA_ASSERT(url != NULL);
@@ -796,7 +795,7 @@ meta2_backend_delete_alias(struct meta2_backend_s *m2b,
 	err = m2b_open(m2b, url, M2V2_OPEN_MASTERONLY|M2V2_OPEN_ENABLED, &sq3);
 	if (!err) {
 		struct sqlx_repctx_s *repctx = NULL;
-		max_versions = _maxvers(sq3, m2b);
+		const gint64 max_versions = _maxvers(sq3, m2b);
 		if (!(err = _transaction_begin(sq3, url, &repctx))) {
 			if (!(err = m2db_delete_alias(sq3, max_versions, url, cb, u0))) {
 				m2db_increment_version(sq3);

--- a/meta2v2/meta2_utils.c
+++ b/meta2v2/meta2_utils.c
@@ -850,8 +850,6 @@ m2db_delete_alias(struct sqlx_sqlite3_s *sq3, gint64 max_versions,
 	if (VERSIONS_DISABLED(max_versions) || VERSIONS_SUSPENDED(max_versions) ||
 			oio_url_has(url, OIOURL_VERSION) || ALIASES_get_deleted(alias)) {
 
-		GRID_TRACE("deleting now");
-
 		GSList *deleted_beans = NULL;
 		err = _real_delete(sq3, beans, &deleted_beans);
 		/* Client asked to remove no-more referenced beans, we tell him which */
@@ -867,10 +865,6 @@ m2db_delete_alias(struct sqlx_sqlite3_s *sq3, gint64 max_versions,
 		if (!err)
 			err = _db_del_FK_by_name (alias, "properties", sq3->db);
 
-	} else if (oio_url_has(url, OIOURL_VERSION)) {
-		/* Alias is in a snapshot but user explicitly asked for its deletion */
-		err = NEWERROR(CODE_NOT_ALLOWED,
-				"Cannot delete a content belonging to a snapshot");
 	} else {
 		gint64 now = oio_ext_real_time () / G_TIME_SPAN_SECOND;
 		/* Create a new version marked as deleted */
@@ -1515,7 +1509,7 @@ _m2_generate_content_chunk(struct gen_ctx_s *ctx, struct service_info_s *si,
 
 	GRID_TRACE2("%s(%s)", __FUNCTION__, oio_url_get(ctx->url, OIOURL_WHOLE));
 
-	oio_str_randomize (binid, sizeof(binid));
+	oio_buf_randomize (binid, sizeof(binid));
 	oio_str_bin2hex (binid, sizeof(binid), strid, sizeof(strid));
 	grid_addrinfo_to_string(&(si->addr), straddr, sizeof(straddr));
 

--- a/meta2v2/meta2_utils_lb.c
+++ b/meta2v2/meta2_utils_lb.c
@@ -70,7 +70,7 @@ _gen_chunk_bean(struct service_info_s *si)
 	gchar *chunkid = NULL;
 	struct bean_CHUNKS_s *chunk = NULL;
 
-	oio_str_randomize (binid, sizeof(binid));
+	oio_buf_randomize (binid, sizeof(binid));
 	oio_str_bin2hex (binid, sizeof(binid), strid, sizeof(strid));
 	grid_addrinfo_to_string(&(si->addr), straddr, sizeof(straddr));
 	chunk = _bean_create(&descr_struct_CHUNKS);

--- a/metautils/lib/metautils_gba.h
+++ b/metautils/lib/metautils_gba.h
@@ -42,9 +42,6 @@ gboolean metautils_gba_equal(const GByteArray *a, const GByteArray *b);
 /** 3-way comparison */
 int metautils_gba_cmp(const GByteArray *a, const GByteArray *b);
 
-/** Replaces the contents of <gba> with random content of the same length */
-void metautils_gba_randomize(GByteArray *gba);
-
 /** Calls g_byte_array_free() on GByteArray in GLib containers */
 void metautils_gba_clean(gpointer p);
 

--- a/metautils/lib/utils_gba.c
+++ b/metautils/lib/utils_gba.c
@@ -19,14 +19,6 @@ License along with this library.
 
 #include "metautils.h"
 
-void
-metautils_gba_randomize(GByteArray *gba)
-{
-	if (unlikely(NULL == gba))
-		return ;
-	oio_str_randomize(gba->data, gba->len);
-}
-
 static int
 metautils_buffer_cmp(const guint8 * const d0, const guint l0,
 		const guint8 * const d1, const guint l1)

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -102,7 +102,6 @@ _reply_m2_error (struct req_args_s *args, GError * err)
 {
 	if (!err)
 		return _reply_success_json (args, NULL);
-	g_prefix_error (&err, "M2 error: ");
 	if (err->code == CODE_CONTAINER_NOTEMPTY)
 		return _reply_conflict_error (args, err);
 	return _reply_common_error (args, err);
@@ -901,10 +900,11 @@ action_m2_container_destroy (struct req_args_s *args)
 	const gboolean hdr_force = _request_has_flag (args, PROXYD_HEADER_MODE, "force");
 	const gboolean opt_force = metautils_cfg_get_bool(OPT("force"), FALSE);
 
-	/* TODO(jfs): const! */
+	/* TODO make this const! */
 	struct sqlx_name_s *name = sqlx_name_mutable_to_const(&n);
-	/* TODO(jfs): manage container subtype */
+	/* XXX manage container subtype */
 	sqlx_name_fill (&n, args->url, NAME_SRVTYPE_META2, 1);
+
 	/* pre-loads the locations of the container. We will need this at the
 	 * destroy step. */
 	err = hc_resolve_reference_service (resolver, args->url, n.type, &urlv);
@@ -979,10 +979,8 @@ action_m2_container_purge (struct req_args_s *args, struct json_object *j UNUSED
 {
 	PACKER_VOID(_pack) { return m2v2_remote_pack_PURGE (args->url); }
 	GError *err = _resolve_meta2 (args, CLIENT_PREFER_MASTER, _pack, NULL);
-	if (NULL != err) {
-		g_prefix_error (&err, "M2 error: ");
+	if (NULL != err)
 		return _reply_common_error (args, err);
-	}
 	return _reply_success_json (args, NULL);
 }
 
@@ -991,10 +989,8 @@ action_m2_container_flush (struct req_args_s *args, struct json_object *j UNUSED
 {
 	PACKER_VOID(_pack) { return m2v2_remote_pack_FLUSH (args->url); }
 	GError *err = _resolve_meta2 (args, CLIENT_PREFER_MASTER, _pack, NULL);
-	if (NULL != err) {
-		g_prefix_error (&err, "M2 error: ");
+	if (NULL != err)
 		return _reply_common_error (args, err);
-	}
 	return _reply_success_json (args, NULL);
 }
 
@@ -1003,10 +999,8 @@ action_m2_container_dedup (struct req_args_s *args, struct json_object *j UNUSED
 {
 	PACKER_VOID(_pack) { return m2v2_remote_pack_DEDUP (args->url); }
 	GError *err = _resolve_meta2 (args, CLIENT_PREFER_MASTER, _pack, NULL);
-	if (NULL != err) {
-		g_prefix_error (&err, "M2 error: ");
+	if (NULL != err)
 		return _reply_common_error (args, err);
-	}
 	return _reply_success_json (args, NULL);
 }
 

--- a/rawx-apache2/src/rawx_repository.c
+++ b/rawx-apache2/src/rawx_repository.c
@@ -222,7 +222,7 @@ dav_rawx_get_resource(request_rec *r, const char *root_dir, const char *label,
 		const char *missing = request_load_chunk_info(r, resource);
 		if (missing != NULL) {
 			return server_create_and_stat_error(request_get_server_config(r), r->pool,
-				HTTP_BAD_REQUEST, 0, apr_pstrcat(r->pool, "Missing header ", missing, NULL));
+				HTTP_BAD_REQUEST, 0, apr_pstrcat(r->pool, "Header error: ", missing, NULL));
 		}
 	}
 


### PR DESCRIPTION
* rawx: fixed error message
* rawx: fixed error message + fixed useless case-sensitivity management
* proxy: cuts the crap from several error messages
* m2v2: unreached code removed from alias deletion
* m2v2: minor cosmetic change
* core/sds: enables tracing RAWX requests for highest verbosity
* proxy: re-enables case sensitive prefix matching in headers (brings more robustness)
* core/sds: checks for content_id's format
* core/sds: new feature to mangle the case of http headers (proxy,
  rawx). Mangling disabled by default, activated in tests.
* core/tool_roundtrip: activates the mangling of headers case
* core: fake chunksnb sent